### PR TITLE
fix: VES ratio always 1.0 due to gold_sql used for both operands in iterated_execution

### DIFF
--- a/premsql/executors/base.py
+++ b/premsql/executors/base.py
@@ -46,10 +46,13 @@ class BaseExecutor(ABC):
 
         if is_match["result"] == 1:
             diff_list = [
+                # Bug fix: denominator must use predicted_sql, not gold_sql.
+                # The original code divided gold_time / gold_time (always 1.0),
+                # making VES meaningless. Correct formula: gold_time / predicted_time.
                 self.execute_sql(sql=gold_sql, dsn_or_db_path=dsn_or_db_path)[
                     "execution_time"
                 ]
-                / self.execute_sql(sql=gold_sql, dsn_or_db_path=dsn_or_db_path)[
+                / self.execute_sql(sql=predicted_sql, dsn_or_db_path=dsn_or_db_path)[
                     "execution_time"
                 ]
                 for _ in range(num_iterations)


### PR DESCRIPTION
## What's wrong

In `premsql/executors/base.py`, the `iterated_execution` method computes the efficiency ratio for VES (Valid Efficiency Score) like this:

```python
diff_list = [
    self.execute_sql(sql=gold_sql, ...)['execution_time']
    / self.execute_sql(sql=gold_sql, ...)['execution_time']  # ← same query both sides
    for _ in range(num_iterations)
]
```

Both the numerator and denominator call `execute_sql` with `gold_sql`, so the ratio is always `gold_time / gold_time = 1.0` regardless of how efficient or slow the predicted query actually is. This makes VES a flat constant (100.0 for every matching prediction), giving no useful signal whatsoever.

## Fix

Change the denominator to use `predicted_sql` instead of `gold_sql`:

```python
diff_list = [
    self.execute_sql(sql=gold_sql, ...)['execution_time']
    / self.execute_sql(sql=predicted_sql, ...)['execution_time']  # ← correct
    for _ in range(num_iterations)
]
```

The ratio `gold_time / predicted_time` correctly reflects efficiency: a value > 1.0 means the predicted query is faster than the gold standard, < 1.0 means it's slower. The downstream `mean(sqrt(ratio)) × 100` aggregation then produces a meaningful score.

A short inline comment has been added to the fixed line to document the original bug for future readers.

## Impact

Without this fix, `iterated_execution` silently returns `1.0` for every matching prediction. Any benchmark or leaderboard numbers produced with the existing code are not measuring execution efficiency at all.

No API changes, no new dependencies.